### PR TITLE
Job Timeouts

### DIFF
--- a/command.go
+++ b/command.go
@@ -5,18 +5,40 @@ import (
 	"log"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 // https://stackoverflow.com/a/40770011
-func ExecuteCommand(command string) (stdout string, stderr string, exitCode int) {
+func ExecuteCommand(command string, timeout int) (stdout string, stderr string, exitCode int) {
 	var outbuf, errbuf bytes.Buffer
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 
-	err := cmd.Run()
+	var ch = make(chan struct{}, 1)
+
+	if timeout > 0 {
+		go func() {
+			log.Printf("waiting %d seconds for timeout\n", timeout)
+			time.Sleep(time.Duration(timeout) * time.Second)
+
+			select {
+			case _ = <-ch:
+				log.Println("command already finished, exiting")
+			default:
+				log.Println("command not finished, terminating")
+				if err := cmd.Process.Kill(); err != nil {
+					log.Println(err)
+				}
+			}
+		}()
+	}
+
+	err := cmd.Run() // .Run waits for the process to finish
 	stdout = outbuf.String()
 	stderr = errbuf.String()
+
+	ch <- struct{}{}
 
 	if err != nil {
 		// try to get the exit code
@@ -39,5 +61,6 @@ func ExecuteCommand(command string) (stdout string, stderr string, exitCode int)
 		ws := cmd.ProcessState.Sys().(syscall.WaitStatus)
 		exitCode = ws.ExitStatus()
 	}
+
 	return
 }

--- a/task.go
+++ b/task.go
@@ -44,7 +44,7 @@ func (t Task) FindOnExit(code int) *OnExit {
 }
 
 func (t Task) Execute(taskName string) (exit int) {
-	_, _, exit = ExecuteCommand(t.Command)
+	_, _, exit = ExecuteCommand(t.Command, t.Timeout)
 
 	if Config.PrintOnFinish {
 		log.Printf("Task %s finished with code %d, executing on_exit method", taskName, exit)
@@ -57,7 +57,7 @@ func (t Task) Execute(taskName string) (exit int) {
 	if onExit != nil {
 		if onExit.Command != "" {
 			log.Printf("Running on_exit command for %s; exit code: %d", taskName, exit)
-			_, _, _ = ExecuteCommand(onExit.Command)
+			_, _, _ = ExecuteCommand(onExit.Command, 0)
 		}
 
 		if onExit.Log != "" { // if there is a log statement
@@ -86,7 +86,7 @@ func (t Task) handleRetry(initialExit int) {
 	for i := 0; i < t.Retry.Tries; i++ {
 		log.Printf("Waiting %f seconds to retry", timeout)
 		time.Sleep(time.Millisecond * time.Duration(timeout*1000))
-		_, _, exit = ExecuteCommand(t.Command)
+		_, _, exit = ExecuteCommand(t.Command, t.Timeout)
 
 		if !t.shouldRetry(exit) {
 			break


### PR DESCRIPTION
Kill a job if it takes too long to execute, based on the timeout specified in the job config.

TODO:
Decide what to do regarding regular output i.e. stdout, stderr and exit code.